### PR TITLE
[DATAPLT-2469] Butler build script for forked Polynote

### DIFF
--- a/butler.yml
+++ b/butler.yml
@@ -1,0 +1,6 @@
+default:
+  tasks:
+    pre:
+      - ./scripts/pre.sh
+    build:
+      - ./scripts/build.sh

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -23,7 +23,7 @@ RUN pip3 install -r /tmp/requirements.txt
 # Then build this from the project root using `-f docker/dev/Dockerfile` to select this file.
 # for example (don't forget the dot at the end!):
 # for frontend dev
-#   cd polynote-frontend; npm install; npm run dist; cd..
+#   cd polynote-frontend; npm install; npm run dist; cd ..
 # for image creation
 #   sbt dist
 #   docker build -t strava/polynote:dev -f docker/dev/Dockerfile .

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Build and push Docker images for Polynote.
+# TODO DATAPLT-2330: Call from butler
+# TODO DATAPLT-2332: Better support local building needs
+
+# Build and push Docker image with a commit and branch tag
+set -e
+
+if [ -z "$GIT_SHA" ]; then
+    echo "Environment variable \$GIT_SHA expected to be set (by Butler)"
+    exit 1
+fi
+
+if [ -z "$GIT_BRANCH" ]; then
+    echo "Environment variable \$GIT_BRANCH expected to be set (by Butler)"
+    exit 1
+fi
+
+REPO="docker.strava.com/strava/polynote"
+COMMIT_TAG="$REPO:$GIT_SHA"
+
+
+# only create and push a new image if we are merging to main
+if [[ "$GIT_BRANCH" == "main" ]]; then
+    docker build -t strava/polynote:latest -f docker/dev/Dockerfile .
+
+    BRANCH_TAG="$REPO:$GIT_BRANCH"
+    docker tag strava/polynote:latest $COMMIT_TAG
+
+    docker push $COMMIT_TAG
+fi

--- a/scripts/pre.sh
+++ b/scripts/pre.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ "$GIT_BRANCH" == "main" ]]; then
+    cd "${0%/*}"
+
+    cd polynote-frontend; npm install; npm run dist
+
+    cd ..
+
+    sbt dist
+fi


### PR DESCRIPTION
We need to compile Polynote (npm frontend + sbt) as part of the Butler process. Previously, we manually ran the following commands to compile Polynote and get the image on to ECR:

```shell
# frontend
cd polynote-frontend; npm install; npm run dist
cd ..

# sbt
sbt dist

# docker
docker build --no-cache -t strava/polynote:dev -f docker/dev/Dockerfile .
docker tag strava/polynote:dev docker.strava.com/strava/polynote:test
docker push docker.strava.com/strava/polynote:test
```